### PR TITLE
Pass all props to wrapper, fix #2 (retry)

### DIFF
--- a/src/react-recoil-hooks-testing-library.test.tsx
+++ b/src/react-recoil-hooks-testing-library.test.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { PropsWithChildren, useContext } from 'react';
 import { atom, useRecoilState, useRecoilValue } from 'recoil';
 
 import { act, renderRecoilHook } from './react-recoil-hooks-testing-library';
@@ -78,7 +78,7 @@ describe('react-recoil-hooks-testing-library', () => {
     };
 
     const { result } = renderRecoilHook(useRecoilTestHookWithContext, {
-      wrapper: ({ children }) => (
+      wrapper: ({ children }: PropsWithChildren<{}>) => (
         <MockContext.Provider value="context!">{children}</MockContext.Provider>
       ),
       states: [{ recoilState: atomA, initialValue: 9 }],

--- a/src/react-recoil-hooks-testing-library.test.tsx
+++ b/src/react-recoil-hooks-testing-library.test.tsx
@@ -87,4 +87,72 @@ describe('react-recoil-hooks-testing-library', () => {
     expect(result.current.contextValue).toBe('context!');
     expect(result.current.valueA).toBe(9);
   });
+
+  it('sets initialProps with wrapper', () => {
+    const MockContext = React.createContext('');
+
+    const useRecoilTestHookWithContext = () => {
+      const valueA = useRecoilValue(atomA);
+      const contextValue = useContext(MockContext);
+
+      return { valueA, contextValue };
+    };
+
+    const WrapperWithProviderValue: React.FC<{
+      providerValue: string;
+    }> = ({ children, providerValue }) => (
+      <MockContext.Provider value={providerValue}>
+        {children}
+      </MockContext.Provider>
+    );
+    const { result } = renderRecoilHook(useRecoilTestHookWithContext, {
+      wrapper: WrapperWithProviderValue,
+      states: [{ recoilState: atomA, initialValue: 123 }],
+      initialProps: {
+        providerValue: 'context!',
+      },
+    });
+
+    expect(result.current.contextValue).toBe('context!');
+    expect(result.current.valueA).toBe(123);
+  });
+
+  it('updates wrapper props on rerender', () => {
+    const MockContext = React.createContext('');
+
+    const useRecoilTestHookWithContext = () => {
+      const valueA = useRecoilValue(atomA);
+      const contextValue = useContext(MockContext);
+
+      return { valueA, contextValue };
+    };
+
+    const WrapperWithProviderValue: React.FC<{
+      providerValue: string;
+    }> = ({ children, providerValue }) => (
+      <MockContext.Provider value={providerValue}>
+        {children}
+      </MockContext.Provider>
+    );
+    const { result, rerender } = renderRecoilHook(
+      useRecoilTestHookWithContext,
+      {
+        wrapper: WrapperWithProviderValue,
+        states: [{ recoilState: atomA, initialValue: 123 }],
+        initialProps: {
+          providerValue: 'context 1',
+        },
+      },
+    );
+
+    expect(result.current.contextValue).toBe('context 1');
+    expect(result.current.valueA).toBe(123);
+
+    rerender({
+      providerValue: 'context 2',
+    });
+
+    expect(result.current.contextValue).toBe('context 2');
+    expect(result.current.valueA).toBe(123);
+  });
 });

--- a/src/react-recoil-hooks-testing-library.test.tsx
+++ b/src/react-recoil-hooks-testing-library.test.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useContext } from 'react';
+import React, { useContext } from 'react';
 import { atom, useRecoilState, useRecoilValue } from 'recoil';
 
 import { act, renderRecoilHook } from './react-recoil-hooks-testing-library';
@@ -78,7 +78,7 @@ describe('react-recoil-hooks-testing-library', () => {
     };
 
     const { result } = renderRecoilHook(useRecoilTestHookWithContext, {
-      wrapper: ({ children }: PropsWithChildren<{}>) => (
+      wrapper: ({ children }) => (
         <MockContext.Provider value="context!">{children}</MockContext.Provider>
       ),
       states: [{ recoilState: atomA, initialValue: 9 }],

--- a/src/react-recoil-hooks-testing-library.tsx
+++ b/src/react-recoil-hooks-testing-library.tsx
@@ -9,7 +9,7 @@ interface MockRecoilState {
 
 interface RenderHookOptions {
   states?: MockRecoilState[];
-  wrapper?: React.ComponentType<any> | React.ComponentType;
+  wrapper?: React.FunctionComponent<any>;
 }
 
 function recoilStateWrapper(options?: RenderHookOptions) {

--- a/src/react-recoil-hooks-testing-library.tsx
+++ b/src/react-recoil-hooks-testing-library.tsx
@@ -9,7 +9,7 @@ interface MockRecoilState {
 
 interface RenderHookOptions {
   states?: MockRecoilState[];
-  wrapper?: React.ComponentType;
+  wrapper?: React.ComponentType<any> | React.ComponentType;
 }
 
 function recoilStateWrapper(options?: RenderHookOptions) {
@@ -50,7 +50,7 @@ function renderRecoilHook<P, R>(
   callback: (props: P) => R,
   options?: RenderHookOptions & {
     initialProps?: P;
-    wrapper?: React.ComponentType | React.ComponentType<any>;
+    wrapper?: React.ComponentType<P> | React.ComponentType;
   },
 ): {
   readonly result: {

--- a/src/react-recoil-hooks-testing-library.tsx
+++ b/src/react-recoil-hooks-testing-library.tsx
@@ -30,11 +30,11 @@ function recoilStateWrapper(options?: RenderHookOptions) {
     ));
   };
 
-  return ({ children }: { children?: React.ReactNode }) => {
+  return (props: { children?: React.ReactNode }) => {
     const renderChildren = options?.wrapper ? (
-      <options.wrapper>{children}</options.wrapper>
+      <options.wrapper {...props} />
     ) : (
-      children
+      props.children
     );
 
     return (
@@ -50,7 +50,7 @@ function renderRecoilHook<P, R>(
   callback: (props: P) => R,
   options?: RenderHookOptions & {
     initialProps?: P;
-    wrapper?: React.ComponentType;
+    wrapper?: React.ComponentType | React.ComponentType<any>;
   },
 ): {
   readonly result: {


### PR DESCRIPTION
This updates PR #3 to fix the typescript error: I changed the typing for `RenderHookOptions.wrapper` to allow `React.ComponentType`s which have a type defined for their props -- so now a wrapper component may have props other than `children`.

With this change, however, it's no longer possible to pass an anonymous function as `wrapper` and have typescript infer that its `children` argument is a ReactNode. I searched around for a way to still support this but came up empty: every issue and thread I found on it indicated that the anonymous function (or its props argument) needed to be assigned a type explicitly.

So I've added a typing for the anonymous wrapper function on line 81 of the tests, but if there's a way to accept components with props other than `children` while still supporting untyped anonymous functions then I would love to learn it.