### PR TITLE
chore: update to latest version of recoil

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-recoil-hooks-testing-library",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Simple and complete React hooks testing utilities that encourage good testing practices... with Recoil!",
   "main": "dist/react-recoil-hooks-testing-library.js",
   "types": "dist/types/index.d.ts",
@@ -47,7 +47,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-test-renderer": "^16.8.4",
-    "recoil": "^0.3.1",
+    "recoil": "^0.4.1",
     "rollup": "^1.31.1",
     "rollup-plugin-typescript2": "^0.20.1",
     "standard-version": "^8.0.1",
@@ -58,7 +58,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-test-renderer": "^16.8.4",
-    "recoil": "^0.3.1"
+    "recoil": "^0.4.1"
   },
   "dependencies": {
     "@testing-library/react-hooks": "^3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5022,10 +5022,10 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recoil@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.3.1.tgz#40ef544160d19d76e25de8929d7e512eace13b90"
-  integrity sha512-KNA3DRqgxX4rRC8E7fc6uIw7BACmMPuraIYy+ejhE8tsw7w32CetMm8w7AMZa34wzanKKkev3vl3H7Z4s0QSiA==
+recoil@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.4.1.tgz#1cb2171bc98d41361507131a059d7c3525d8c4fe"
+  integrity sha512-vp6KPwlHOjJ4bJofmdDchmgI9ilMTCoUisK8/WYLl8dThH7e7KmtZttiLgvDb2Em99dUfTEsk8vT8L1nUMgqXQ==
   dependencies:
     hamt_plus "1.0.2"
 


### PR DESCRIPTION
Upgrades package to support 0.4.x recoil versions. 

Note: I basically used https://github.com/inturn/react-recoil-hooks-testing-library/pull/14 as a template for this work, and bumped the package version from 0.1.0 to 0.2.0.

Closes: https://github.com/inturn/react-recoil-hooks-testing-library/issues/18
